### PR TITLE
forward remaining_args to cucumber

### DIFF
--- a/lib/cukunity/cli/argument_parser.rb
+++ b/lib/cukunity/cli/argument_parser.rb
@@ -31,11 +31,13 @@ module Cukunity
         # default options
         defaults =
         {
+          :path => Dir.pwd,
           :verbose => true,
           :ios => true,
           :android => true,
           :help => false
         }
+        defaults[:path] = File.join(defaults[:path], 'features') if File.directory?(File.join(defaults[:path], 'features'))
         options = Cukunity::CLI::Options.new(defaults)
 
         @remaining_args = @args.dup
@@ -44,12 +46,17 @@ module Cukunity
 
           opts.separator ''
           opts.separator 'Commands:'
-          opts.separator 'doctor              Check your system for the required platform tools.'
-          opts.separator 'bootstrap <path>    Bootstrap your Unity project.'
-          opts.separator 'features [<path>]   Run cucumber against path containing feature files.'
+          opts.separator 'doctor                     Check your system for the required platform tools.'
+          opts.separator 'bootstrap <path>           Bootstrap your Unity project.'
+          opts.separator 'features [--path=<path>]   Run cucumber against path containing feature files.'
 
           opts.separator ''
           opts.separator 'Options:'
+
+          # --path
+          opts.on('-p', '--path', '=<path>', 'Features path.') do |path|
+            options.path = path
+          end
 
           # --verbose
           opts.on('-v', '--[no-]verbose', 'Enable/Disable verbose mode.') do |v|

--- a/lib/cukunity/cli/argument_parser.rb
+++ b/lib/cukunity/cli/argument_parser.rb
@@ -46,9 +46,12 @@ module Cukunity
 
           opts.separator ''
           opts.separator 'Commands:'
-          opts.separator 'doctor                     Check your system for the required platform tools.'
-          opts.separator 'bootstrap <path>           Bootstrap your Unity project.'
-          opts.separator 'features [--path=<path>]   Run cucumber against path containing feature files.'
+          opts.separator 'doctor'
+          opts.separator '    Check your system for the required platform tools.'
+          opts.separator 'bootstrap <path>'
+          opts.separator '    Bootstrap your Unity project.'
+          opts.separator 'features [--path=<path>] [<cucumber-opts>...]'
+          opts.separator '    Run cucumber against path containing feature files.'
 
           opts.separator ''
           opts.separator 'Options:'

--- a/lib/cukunity/cli/features_command.rb
+++ b/lib/cukunity/cli/features_command.rb
@@ -24,7 +24,10 @@ module Cukunity
             'either --ios or --android'
         end
         cukunity = File.expand_path(File.join(File.dirname(__FILE__), '..', 'cucumber.rb'))
-        system %Q[cucumber --require "#{cukunity}" --require "#{path}" --format pretty -t "#{platform_flags}"]
+
+        cucumber_args = ['--require', cukunity, '--require', path, '--format', 'pretty', '-t', platform_flags]
+        cucumber_args += @parser.remaining_args
+        system 'cucumber', *cucumber_args
       end
     end
   end

--- a/lib/cukunity/cli/features_command.rb
+++ b/lib/cukunity/cli/features_command.rb
@@ -9,11 +9,7 @@ module Cukunity
       end
 
       def execute
-        path = @parser.remaining_args.first
-        if path.nil?
-          path = Dir.pwd
-          path = File.join(path, 'features') if File.directory?(File.join(path, 'features'))
-        end
+        path = @parser.options.path
         if @parser.options.ios
           if @parser.options.android
             abort 'You cannot test both iOS and Android simultaneously. ' \


### PR DESCRIPTION
this is necessary in order to tell cucumber to run a subset of the features instead of the whole suite.
